### PR TITLE
Restructure the React Router app architecture

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,18 +1,28 @@
-import { Outlet } from 'react-router-dom';
+import { Route, Routes, HashRouter } from 'react-router-dom';
+
 import Header from './components/Header';
 import Footer from './components/Footer';
+import Search from './components/Search';
+import Category from './components/Category';
+import Ingredient from './components/Ingredient';
+import Meal from './components/Meal';
 
 import './App.css';
 
 function App() {
   return (
-    <div>
+    <HashRouter>
       <Header />
       <main className='app-main-container'>
-        <Outlet />
+      <Routes>
+        <Route path='/' element={<Search />} />
+        <Route path='/category/:name' element={<Category />} />
+        <Route path='/ingredient/:name' element={<Ingredient />} />
+        <Route path='/meal/:id' element={<Meal />} />
+      </Routes>
       </main>
       <Footer />
-    </div>
+    </HashRouter>
   );
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,33 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { Route, RouterProvider, createHashRouter, createRoutesFromElements } from 'react-router-dom';
 
 import './index.css';
-
 import App from './App';
-import Search from './components/Search';
-import Category from './components/Category';
-import Ingredient from './components/Ingredient';
-import Error from './components/Error';
 
 import reportWebVitals from './reportWebVitals';
-import Meal from './components/Meal';
-
-const router = createHashRouter(
-  createRoutesFromElements(
-    <Route path='/' element={<App />} errorElement={<Error />}>
-      <Route path='' element={<Search />} />
-      <Route path='/category/:name' element={<Category />} />
-      <Route path='/ingredient/:name' element={<Ingredient />} />
-      <Route path='/meal/:id' element={<Meal />} />
-    </Route>
-  )
-);
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <App />
   </React.StrictMode>
 );
 


### PR DESCRIPTION
### Changelog

- Remove the data API portion (createHashRouter, RouterProvider, etc) as we don't need them
- Simplify the structure to improve code readability and maintainability